### PR TITLE
Yarn v3 upgrade (well, cancelling the warning anyway)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+yarnPath: .yarn/releases/yarn-3.5.0.cjs
+nodeLinker: node_modules

--- a/package.json
+++ b/package.json
@@ -44,10 +44,7 @@
     "sonar-scanner": "^3.1.0"
   },
   "resolutions": {
-    "codeceptjs/**/mocha": "^10.0.0",
-    "request/**/http-signature": "^1.3.6",
-    "request/**/qs": "^6.11.0",
-    "@hmcts/nodejs-healthcheck/**/superagent": "^8.0.6",
     "@sideway/formula": "^3.0.1"
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }


### PR DESCRIPTION
The yarn v3 upgrade pipeline check greps the package.json file for the "packagemanager" value. Have upgraded y'all to v3.5 to trigger that (hopefully). Sorry for messing up your workflows this week!

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
