### PR TITLE
[SSCSSI-263]: add Action Unprocessed correspondence CTSC task work allocation tests

### DIFF
--- a/functional-test/e2e/supplementary.response.spec.ts
+++ b/functional-test/e2e/supplementary.response.spec.ts
@@ -2,11 +2,12 @@ import { test } from "../lib/steps.factory";
 import createCaseBasedOnCaseType from "../api/client/sscs/factory/appeal.type.factory";
 import performAppealDormantOnCase from "../api/client/sscs/appeal.event";
 
-let caseId : string;
 
 test.describe.serial('WA - Action Unprocessed Correspondence CTSC task initiation and completion tests', {
     tag: '@work-allocation'
 }, async () => {
+
+    let caseId : string;
 
     test.beforeAll("Create case and allocate to CTSC Admin", async ({ supplementaryResponseSteps }) => {
         caseId = await createCaseBasedOnCaseType('PIP');

--- a/functional-test/e2e/supplementary.response.spec.ts
+++ b/functional-test/e2e/supplementary.response.spec.ts
@@ -1,0 +1,63 @@
+import { test } from "../lib/steps.factory";
+import createCaseBasedOnCaseType from "../api/client/sscs/factory/appeal.type.factory";
+import performAppealDormantOnCase from "../api/client/sscs/appeal.event";
+
+let caseId : string;
+
+test.describe.serial('WA - Action Unprocessed Correspondence CTSC task initiation and completion tests', {
+    tag: '@work-allocation'
+}, async () => {
+
+    test.beforeAll("Create case and allocate to CTSC Admin", async ({ supplementaryResponseSteps }) => {
+        caseId = await createCaseBasedOnCaseType('PIP');
+        await supplementaryResponseSteps.allocateCaseToCtscUser(caseId);
+    });
+
+    test("As a DWP user, provide supplementary response", async ({
+        supplementaryResponseSteps }) => {
+
+        test.slow();
+        await supplementaryResponseSteps.performSupplementaryResponse(caseId);
+    });
+
+    test("CTSC Admin as allocated case worker, views the Action Unprocessed Correspondence task", async ({
+        supplementaryResponseSteps }) => {
+
+        test.slow();
+        await supplementaryResponseSteps.verifyCtscAdminAsAllocatedCaseWorkerCanViewTheAutomaticallyAssignedActionUnprocessedCorrespondenceTask(caseId);
+    });
+
+    test("CTSC Admin as allocated case worker, completes the Action Unprocessed Correspondence task", async ({
+        supplementaryResponseSteps }) => {
+
+        test.slow();
+        await supplementaryResponseSteps.verifyCtscAdminAsAllocatedCaseWorkerCanCompleteTheAssignedActionUnprocessedCorrespondenceTask(caseId);
+    });
+
+    test.afterAll("Case has to be set to Dormant", async () => {
+        await performAppealDormantOnCase(caseId);
+    });
+});
+
+test.describe('WA - Action Unprocessed Correspondence CTSC task cancellation', {
+    tag: '@work-allocation'
+}, async() => {
+
+    let caseId : string;
+    
+    test.beforeAll("Create case and allocate to CTSC Admin", async ({ supplementaryResponseSteps }) => {
+        caseId = await createCaseBasedOnCaseType('PIP');
+        await supplementaryResponseSteps.allocateCaseToCtscUser(caseId);
+    });
+
+    test("CTSC Admin as allocated case worker, cancels the Action Unprocessed Correspondence CTSC task manually", async ({
+        supplementaryResponseSteps}) => {
+
+        test.slow();
+        await supplementaryResponseSteps.verifyActionUnprocessedCorrespondenceTaskCanBeCancelledManuallyByAllocatedCtscAdmin(caseId);
+    });
+
+    test.afterAll("Case has to be set to Dormant", async () => {
+        await performAppealDormantOnCase(caseId);
+    });
+});

--- a/functional-test/e2e/upload.document.further.evidence.spec.ts
+++ b/functional-test/e2e/upload.document.further.evidence.spec.ts
@@ -1,0 +1,62 @@
+import { test } from "../lib/steps.factory";
+import createCaseBasedOnCaseType from "../api/client/sscs/factory/appeal.type.factory";
+import performAppealDormantOnCase from "../api/client/sscs/appeal.event";
+
+let caseId : string;
+
+test.describe.serial('WA - Action Unprocessed Correspondence CTSC task initiation and completion tests', {
+    tag: '@work-allocation'
+}, async () => {
+
+    test.beforeAll("Create case and allocate to CTSC Admin", async ({ uploadDocumentFurtherEvidenceSteps }) => {
+        caseId = await createCaseBasedOnCaseType('PIP');
+        await uploadDocumentFurtherEvidenceSteps.allocateCaseToCtscUser(caseId);
+    });
+
+    test("As a CTSC Admin, upload document further evidence", async ({
+        uploadDocumentFurtherEvidenceSteps }) => {
+
+        test.slow();
+        await uploadDocumentFurtherEvidenceSteps.performUploadDocumentFurtherEvidence(caseId);
+    });
+
+    test("CTSC Admin as allocated case worker, views the Action Unprocessed Correspondence CTSC task", async ({
+        uploadDocumentFurtherEvidenceSteps }) => {
+
+        test.slow();
+        await uploadDocumentFurtherEvidenceSteps.verifyCtscAdminAsAllocatedCaseWorkerCanViewTheAutomaticallyAssignedActionUnprocessedCorrespondenceTask(caseId);
+    });
+
+    test("CTSC Admin as allocated case worker, completes the Action Unprocessed Correspondence CTSC task", async ({
+        uploadDocumentFurtherEvidenceSteps }) => {
+
+        test.slow();
+        await uploadDocumentFurtherEvidenceSteps.verifyCtscAdminAsAllocatedCaseWorkerCanCompleteTheAssignedActionUnprocessedCorrespondenceTask(caseId);
+    });
+
+    test.afterAll("Case has to be set to Dormant", async () => {
+        await performAppealDormantOnCase(caseId);
+    });
+});
+
+test.describe('WA - Action Unprocessed Correspondence CTSC task cancellation', {
+    tag: '@work-allocation'
+}, async() => {
+
+    let caseId : string;
+    
+    test.beforeAll("Create case", async () => {
+        caseId = await createCaseBasedOnCaseType('PIP');
+    });
+
+    test("CTSC Admin cancels the unassigned Action Unprocessed Correspondence CTSC task manually", async ({
+        uploadDocumentFurtherEvidenceSteps}) => {
+
+        test.slow();
+        await uploadDocumentFurtherEvidenceSteps.verifyUnassignedActionUnprocessedCorrespondenceTaskCanBeCancelledManuallyByCtscAdmin(caseId);
+    });
+
+    test.afterAll("Case has to be set to Dormant", async () => {
+        await performAppealDormantOnCase(caseId);
+    });
+});

--- a/functional-test/e2e/upload.document.further.evidence.spec.ts
+++ b/functional-test/e2e/upload.document.further.evidence.spec.ts
@@ -2,11 +2,12 @@ import { test } from "../lib/steps.factory";
 import createCaseBasedOnCaseType from "../api/client/sscs/factory/appeal.type.factory";
 import performAppealDormantOnCase from "../api/client/sscs/appeal.event";
 
-let caseId : string;
 
 test.describe.serial('WA - Action Unprocessed Correspondence CTSC task initiation and completion tests', {
     tag: '@work-allocation'
 }, async () => {
+
+    let caseId : string;
 
     test.beforeAll("Create case and allocate to CTSC Admin", async ({ uploadDocumentFurtherEvidenceSteps }) => {
         caseId = await createCaseBasedOnCaseType('PIP');

--- a/functional-test/e2e/work-allocation/wa.review.admin.action.task.spec.ts
+++ b/functional-test/e2e/work-allocation/wa.review.admin.action.task.spec.ts
@@ -2,11 +2,13 @@ import { test } from "../../lib/steps.factory";
 import createCaseBasedOnCaseType from "../../api/client/sscs/factory/appeal.type.factory";
 import performAppealDormantOnCase from "../../api/client/sscs/appeal.event";
 
-let caseId : string;
+
 
 test.describe.serial('WA - Review Admin action task tests', {
     tag: '@work-allocation'
 }, async () => {
+
+    let caseId : string;
 
     test.beforeAll("Case has to be Created",async () => {
         caseId = await createCaseBasedOnCaseType('PIP');

--- a/functional-test/e2e/work-allocation/wa.review.bf.date.task.spec.ts
+++ b/functional-test/e2e/work-allocation/wa.review.bf.date.task.spec.ts
@@ -2,11 +2,11 @@ import { test } from "../../lib/steps.factory";
 import createCaseBasedOnCaseType from "../../api/client/sscs/factory/appeal.type.factory";
 import performAppealDormantOnCase from "../../api/client/sscs/appeal.event";
 
-let caseId : string;
-
 test.describe.serial('WA - Review BF Date CTSC task initiation and completion tests', {
     tag: '@work-allocation'
 }, async () => {
+
+    let caseId : string;
 
     test.beforeAll("Case has to be Created",async () => {
         caseId = await createCaseBasedOnCaseType('PIP');

--- a/functional-test/e2e/work-allocation/wa.review.bf.date.task.spec.ts
+++ b/functional-test/e2e/work-allocation/wa.review.bf.date.task.spec.ts
@@ -12,14 +12,14 @@ test.describe.serial('WA - Review BF Date CTSC task initiation and completion te
         caseId = await createCaseBasedOnCaseType('PIP');
     });
 
-    test("CSTC Admin as allocated case worker, views the review BF date task", async ({
+    test("CTSC Admin as allocated case worker, views the review BF date task", async ({
         reviewBFDateTaskSteps }) => {
 
         test.slow();
         await reviewBFDateTaskSteps.verifyCtscAdminAsAllocatedCaseWorkerCanViewTheAutomaticallyAssignedReviewBFDateTask(caseId);
     });
 
-    test("CSTC Admin as allocated case worker, completes the review BF date task", async ({
+    test("CTSC Admin as allocated case worker, completes the review BF date task", async ({
         reviewBFDateTaskSteps }) => {
 
         test.slow();

--- a/functional-test/e2e/work-allocation/wa.review.incomplete.appeal.task.spec.ts
+++ b/functional-test/e2e/work-allocation/wa.review.incomplete.appeal.task.spec.ts
@@ -12,21 +12,21 @@ test.describe.serial('WA - Review Incomplete Appeal CTSC task initiation and com
         caseId = await createCaseBasedOnCaseType('PIPINCOMPLETE');
     });
 
-    test("As a CSTC Admin without case allocator role, review Incomplete Appeal task", async ({
+    test("As a CTSC Admin without case allocator role, review Incomplete Appeal task", async ({
         reviewIncompleteAppealTaskSteps}) => {
 
         test.slow();
         await reviewIncompleteAppealTaskSteps.verifyCtscAdminWithoutCaseAllocatorRoleCanViewReviewIncompleteAppealTask(caseId);
     });
 
-    test("As a CSTC Admin with case allocator role, assign Incomplete Appeal task to another CTSC admin", async ({
+    test("As a CTSC Admin with case allocator role, assign Incomplete Appeal task to another CTSC admin", async ({
         reviewIncompleteAppealTaskSteps }) => {
 
         test.slow();
         await reviewIncompleteAppealTaskSteps.verifyCtscAdminWithCaseAllocatorRoleCanViewAndAssignReviewIncompleteAppealTask(caseId);
     });
 
-    test("As a CSTC Admin, view and complete the assigned Review Incomplete Appeal CTSC task", async ({
+    test("As a CTSC Admin, view and complete the assigned Review Incomplete Appeal CTSC task", async ({
         reviewIncompleteAppealTaskSteps }) => {
 
         test.slow();

--- a/functional-test/e2e/work-allocation/wa.review.listing.error.task.spec.ts
+++ b/functional-test/e2e/work-allocation/wa.review.listing.error.task.spec.ts
@@ -12,7 +12,7 @@ test.describe.serial('WA - Review Listing Error CTSC task initiation and complet
         caseId = await createCaseBasedOnCaseType('PIP');
     });
 
-    test("As a CSTC Admin without case allocator role, review listing error task", async ({
+    test("As a CTSC Admin without case allocator role, review listing error task", async ({
         reviewListingErrorTaskSteps}) => {
 
         // Below step ensures test timeout is extended to allow enough time for task creation
@@ -20,14 +20,14 @@ test.describe.serial('WA - Review Listing Error CTSC task initiation and complet
         await reviewListingErrorTaskSteps.verifyCtscAdminWithoutCaseAllocatorRoleCanViewReviewListingErrorTask(caseId);
     });
 
-    test("As a CSTC Admin with case allocator role, review listing error task", async ({
+    test("As a CTSC Admin with case allocator role, review listing error task", async ({
         reviewListingErrorTaskSteps }) => {
 
         test.slow();
         await reviewListingErrorTaskSteps.verifyCtscAdminWithCaseAllocatorRoleCanViewReviewListingErrorTask(caseId);
     });
 
-    test("As a CSTC Administrator, complete listing error task", async ({
+    test("As a CTSC Administrator, complete listing error task", async ({
         reviewListingErrorTaskSteps }) => {
 
         test.slow();

--- a/functional-test/fixtures/steps/base.ts
+++ b/functional-test/fixtures/steps/base.ts
@@ -24,6 +24,9 @@ import { CreateBundle } from './create.bundle';
 import { CreateBundlePage } from '../../pages/create.bundle';
 import {LinkCasePage} from "../../pages/link.case.page";
 import { RolesAndAccess } from "../../pages/tabs/roles.and.access";
+import { SupplementaryResponsePage } from "../../pages/supplementary.response.page";
+import { UploadDocumentFurtherEvidencePage } from '../../pages/upload.document.further.evidence.page';
+
 
 export abstract class BaseStep {
 
@@ -51,6 +54,8 @@ export abstract class BaseStep {
   protected requestInfoFromPartyPage: RequestInfoFromPartyPage;
   protected linkACasePage: LinkCasePage;
   protected rolesAndAccessTab: RolesAndAccess;
+  protected supplementaryResponsePage: SupplementaryResponsePage;
+  protected uploadDocumentFurtherEvidencePage: UploadDocumentFurtherEvidencePage;
 
 
    constructor(page: Page) {
@@ -78,6 +83,8 @@ export abstract class BaseStep {
         this.createBundlePage = new CreateBundlePage(this.page);
         this.linkACasePage = new LinkCasePage(this.page);
         this.rolesAndAccessTab = new RolesAndAccess(this.page);
+        this.supplementaryResponsePage = new SupplementaryResponsePage(this.page);
+        this.uploadDocumentFurtherEvidencePage = new UploadDocumentFurtherEvidencePage(this.page);
    }
 
     async loginUserWithCaseId(user, clearCacheFlag: boolean = false, caseId?: string) {

--- a/functional-test/fixtures/steps/supplementary.response.ts
+++ b/functional-test/fixtures/steps/supplementary.response.ts
@@ -1,0 +1,104 @@
+import { Page, expect } from '@playwright/test';
+import task from '../../pages/content/action.unprocessed.correspondence.task_en.json';
+import { BaseStep } from './base';
+import { credentials } from '../../config/config';
+import eventTestData from '../../pages/content/event.name.event.description_en.json';
+import supplementaryResponseData from '../../pages/content/supplementary.response_en.json';
+import actionFurtherEvidenceTestdata from '../../pages/content/action.further.evidence_en.json';
+
+
+export class SupplementaryResponse extends BaseStep {
+
+    readonly page : Page;
+
+    constructor(page: Page) {
+        super(page);
+        this.page = page;
+    }
+
+    async performSupplementaryResponse(caseId: string) {
+
+        // Dwp user performs Supplementary response event
+        await this.loginUserWithCaseId(credentials.dwpResponseWriter, false, caseId);
+        await this.homePage.reloadPage();
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.chooseEvent('Supplementary response');
+
+        await this.supplementaryResponsePage.verifyPageContent();
+        await this.supplementaryResponsePage.uploadSupplementaryResponseDoc(supplementaryResponseData.testfileone);
+        await this.supplementaryResponsePage.selectFtaState(supplementaryResponseData.ftaState);
+        await this.supplementaryResponsePage.chooseFtaRecommendPoToAttend(supplementaryResponseData.poAttendOption);
+        await this.supplementaryResponsePage.continueSubmission();
+
+        await this.supplementaryResponsePage.verifyCYAPageContent();
+        await this.supplementaryResponsePage.confirmSubmission();
+        await expect(this.homePage.summaryTab).toBeVisible();
+    }
+
+    async allocateCaseToCtscUser(caseId: string) {
+        // CTSC Admin with case allocator role allocates case to another CTSC Admin
+        await this.loginUserWithCaseId(credentials.amCaseWorkerWithCaseAllocatorRole, false, caseId);
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.delay(3000);
+        await this.homePage.navigateToTab('Roles and access');
+        await this.rolesAndAccessTab.allocateCtscRole(credentials.amCaseWorker.email);
+    }
+
+    async verifyCtscAdminAsAllocatedCaseWorkerCanViewTheAutomaticallyAssignedActionUnprocessedCorrespondenceTask(caseId: string) {
+
+        // Action Unprocessed Correspondence task is automatically assigned to allocated CTSC Admin
+        await this.loginUserWithCaseId(credentials.amCaseWorker, false, caseId);
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+    }
+
+    async verifyCtscAdminAsAllocatedCaseWorkerCanCompleteTheAssignedActionUnprocessedCorrespondenceTask(caseId: string) {
+
+        // Verify CTSC Admin as allocated caseworker can see the assigned Action Unprocessed Correspondence task
+        await this.loginUserWithCaseId(credentials.amCaseWorker, true, caseId);
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+
+        // CTSC Admin verifies assigned task details
+        await this.tasksTab.verifyPriortiy(task.name, task.priority);
+        await this.tasksTab.verifyPageContentByKeyValue(task.name, 'Assigned to', task.assignedTo);
+        await this.tasksTab.verifyManageOptions(task.name, task.assignedManageOptions);
+        await this.tasksTab.verifyNextStepsOptions(task.name, task.nextStepsOptions);
+
+        // Select Action Further Evidence next step and complete the event
+        await this.tasksTab.clickNextStepLink(task.actionFurtherEvidence.link);
+
+        await this.actionFurtherEvidencePage.selectFEOption();
+        await this.actionFurtherEvidencePage.selectSenderOption(actionFurtherEvidenceTestdata.ftaSender);
+        await this.actionFurtherEvidencePage.selectbundle();
+        await this.actionFurtherEvidencePage.confirmSubmission();
+
+        await this.eventNameAndDescriptionPage.verifyPageContent(actionFurtherEvidenceTestdata.eventName);
+        await this.eventNameAndDescriptionPage.inputData(eventTestData.eventSummaryInput,
+            eventTestData.eventDescriptionInput);
+        await this.eventNameAndDescriptionPage.confirmSubmission();
+
+        // Verify task is removed from the tasks list within Tasks tab
+        await this.tasksTab.verifyTaskIsHidden(task.name);
+    }
+
+    async verifyActionUnprocessedCorrespondenceTaskCanBeCancelledManuallyByAllocatedCtscAdmin(caseId: string) {
+
+        // Dwp user performs Supplementary response event
+        await this.performSupplementaryResponse(caseId);
+
+        // Verify CTSC Admin as allocated caseworker can view the automatically assigned Action Unprocessed Correspondence task
+        await this.loginUserWithCaseId(credentials.amCaseWorker, true, caseId);
+        await this.homePage.navigateToTab('Tasks')
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+        await this.tasksTab.verifyManageOptions(task.name, task.assignedManageOptions);
+        await this.tasksTab.verifyNextStepsOptions(task.name, task.nextStepsOptions);
+
+        // CTSC Admin cancels the task manually
+        await this.tasksTab.cancelTask(task.name);
+
+        // Verify task is removed from the tasks list within Tasks tab
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsHidden(task.name);
+    }
+}

--- a/functional-test/fixtures/steps/supplementary.response.ts
+++ b/functional-test/fixtures/steps/supplementary.response.ts
@@ -78,6 +78,9 @@ export class SupplementaryResponse extends BaseStep {
             eventTestData.eventDescriptionInput);
         await this.eventNameAndDescriptionPage.confirmSubmission();
 
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.delay(3000);
+
         // Verify task is removed from the tasks list within Tasks tab
         await this.tasksTab.verifyTaskIsHidden(task.name);
     }

--- a/functional-test/fixtures/steps/upload.document.further.evidence.ts
+++ b/functional-test/fixtures/steps/upload.document.further.evidence.ts
@@ -81,6 +81,9 @@ export class UploadDocumentFurtherEvidence extends BaseStep {
             eventTestData.eventDescriptionInput);
         await this.eventNameAndDescriptionPage.confirmSubmission();
 
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.delay(3000);
+
         await this.tasksTab.verifyTaskIsHidden(task.name);
     }
 

--- a/functional-test/fixtures/steps/upload.document.further.evidence.ts
+++ b/functional-test/fixtures/steps/upload.document.further.evidence.ts
@@ -1,0 +1,106 @@
+import { Page, expect } from '@playwright/test';
+import task from '../../pages/content/action.unprocessed.correspondence.task_en.json';
+import { BaseStep } from './base';
+import { credentials } from '../../config/config';
+import eventTestData from '../../pages/content/event.name.event.description_en.json';
+import actionFurtherEvidenceTestdata from '../../pages/content/action.further.evidence_en.json';
+import uploadDocumentFurtherEvidenceData from '../../pages/content/upload.document.further.evidence_en.json';
+
+
+export class UploadDocumentFurtherEvidence extends BaseStep {
+
+    readonly page : Page;
+
+    constructor(page: Page) {
+        super(page);
+        this.page = page;
+    }
+
+    async performUploadDocumentFurtherEvidence(caseId: string) {
+
+        await this.loginUserWithCaseId(credentials.amCaseWorkerWithCaseAllocatorRole, false, caseId);
+        await this.homePage.reloadPage();
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.chooseEvent('Upload document FE');
+
+        await this.uploadDocumentFurtherEvidencePage.verifyPageContent();
+        await this.uploadDocumentFurtherEvidencePage.clickAddNew();
+        await this.uploadDocumentFurtherEvidencePage.selectDocumenType(uploadDocumentFurtherEvidenceData.documentType);
+        await this.uploadDocumentFurtherEvidencePage.inputFilename(uploadDocumentFurtherEvidenceData.fileName);
+        await this.uploadDocumentFurtherEvidencePage.uploadFurtherEvidenceDoc(uploadDocumentFurtherEvidenceData.testfileone);
+        await this.uploadDocumentFurtherEvidencePage.confirmSubmission();
+
+        await this.eventNameAndDescriptionPage.verifyPageContent(uploadDocumentFurtherEvidenceData.eventName);
+        await this.eventNameAndDescriptionPage.inputData(eventTestData.eventSummaryInput,
+            eventTestData.eventDescriptionInput);
+        await this.eventNameAndDescriptionPage.confirmSubmission();
+
+        await expect(this.homePage.summaryTab).toBeVisible();
+    }
+
+    async allocateCaseToCtscUser(caseId: string) {
+        // CTSC Admin with case allocator role allocates case to another CTSC Admin
+        await this.loginUserWithCaseId(credentials.amCaseWorkerWithCaseAllocatorRole, false, caseId);
+        await expect(this.homePage.summaryTab).toBeVisible();
+        await this.homePage.delay(3000);
+        await this.homePage.navigateToTab('Roles and access');
+        await this.rolesAndAccessTab.allocateCtscRole(credentials.amCaseWorker.email);
+    }
+
+    async verifyCtscAdminAsAllocatedCaseWorkerCanViewTheAutomaticallyAssignedActionUnprocessedCorrespondenceTask(caseId: string) {
+
+        // Action Unprocessed Correspondence task is automatically assigned to allocated CTSC Admin
+        await this.loginUserWithCaseId(credentials.amCaseWorker, false, caseId);
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+    }
+
+    async verifyCtscAdminAsAllocatedCaseWorkerCanCompleteTheAssignedActionUnprocessedCorrespondenceTask(caseId: string) {
+
+        // Verify CTSC Admin as allocated caseworker can see the assigned Action Unprocessed Correspondence task
+        await this.loginUserWithCaseId(credentials.amCaseWorker, true, caseId);
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+
+        // CTSC Admin verifies assigned task details
+        await this.tasksTab.verifyPriortiy(task.name, task.priority);
+        await this.tasksTab.verifyPageContentByKeyValue(task.name, 'Assigned to', task.assignedTo);
+        await this.tasksTab.verifyManageOptions(task.name, task.assignedManageOptions);
+        await this.tasksTab.verifyNextStepsOptions(task.name, task.nextStepsOptions);
+
+        // Select Action Further Evidence next step and complete the event
+        await this.tasksTab.clickNextStepLink(task.actionFurtherEvidence.link);
+
+        await this.actionFurtherEvidencePage.selectFEOption();
+        await this.actionFurtherEvidencePage.selectSenderOption(actionFurtherEvidenceTestdata.ftaSender);
+        await this.actionFurtherEvidencePage.selectbundle();
+        await this.actionFurtherEvidencePage.confirmSubmission();
+
+        await this.eventNameAndDescriptionPage.verifyPageContent(actionFurtherEvidenceTestdata.eventName);
+        await this.eventNameAndDescriptionPage.inputData(eventTestData.eventSummaryInput,
+            eventTestData.eventDescriptionInput);
+        await this.eventNameAndDescriptionPage.confirmSubmission();
+
+        await this.tasksTab.verifyTaskIsHidden(task.name);
+    }
+
+    async verifyUnassignedActionUnprocessedCorrespondenceTaskCanBeCancelledManuallyByCtscAdmin(caseId: string) {
+
+        // CTSC Admin with case allocator role performs Upload document further evidence event
+        await this.performUploadDocumentFurtherEvidence(caseId);
+
+        // Verify CTSC Admin can view the unassigned Action Unprocessed Correspondence task
+        await this.loginUserWithCaseId(credentials.amCaseWorker, true, caseId);
+        await this.homePage.navigateToTab('Tasks')
+        await this.tasksTab.verifyTaskIsDisplayed(task.name);
+        await this.tasksTab.verifyPageContentByKeyValue(task.name, 'Assigned to', task.assignedToWhenNotAssigned);
+        await this.tasksTab.verifyManageOptions(task.name, task.unassignedManageOptions);
+
+        // CTSC Admin cancels the task manually
+        await this.tasksTab.cancelTask(task.name);
+
+        // Verify task is removed from the tasks list within Tasks tab
+        await this.homePage.navigateToTab('Tasks');
+        await this.tasksTab.verifyTaskIsHidden(task.name);
+    }
+}

--- a/functional-test/lib/steps.factory.ts
+++ b/functional-test/lib/steps.factory.ts
@@ -26,6 +26,8 @@ import { AppealDormant } from '../fixtures/steps/appeal.dormant';
 import {DeathOfAnAppelant} from "../fixtures/steps/death.of.an.appelant";
 import {LinkCase} from "../fixtures/steps/link-case";
 import { ReviewBFDateTask } from '../fixtures/steps/work-allocation/review.bf.date.task';
+import { SupplementaryResponse } from '../fixtures/steps/supplementary.response';
+import { UploadDocumentFurtherEvidence } from '../fixtures/steps/upload.document.further.evidence';
 
 
 
@@ -57,6 +59,8 @@ type MyStepsFixtures = {
     deathOfAppellant : DeathOfAnAppelant
     linkACaseSteps: LinkCase
     reviewBFDateTaskSteps: ReviewBFDateTask
+    supplementaryResponseSteps: SupplementaryResponse
+    uploadDocumentFurtherEvidenceSteps: UploadDocumentFurtherEvidence
 };
 
 export const test =  stepsFactory.extend<MyStepsFixtures>({
@@ -167,5 +171,13 @@ export const test =  stepsFactory.extend<MyStepsFixtures>({
     reviewBFDateTaskSteps:async ({ page }, use) => {
         const reviewBFDateTaskSteps = new ReviewBFDateTask(page);
         await use(reviewBFDateTaskSteps);
+    },
+    supplementaryResponseSteps:async ({ page }, use) => {
+        const supplementaryResponseSteps = new SupplementaryResponse(page);
+        await use(supplementaryResponseSteps);
+    },
+    uploadDocumentFurtherEvidenceSteps:async ({ page }, use) => {
+        const uploadDocumentFurtherEvidenceSteps = new UploadDocumentFurtherEvidence(page);
+        await use(uploadDocumentFurtherEvidenceSteps);
     }
 })

--- a/functional-test/pages/action.further.evidence.page.ts
+++ b/functional-test/pages/action.further.evidence.page.ts
@@ -48,7 +48,7 @@ export class ActionFurtherEvidencePage {
     }
 
     async confirmSubmission(): Promise<void> {
-        await webActions.clickSubmitButton();
+        await webActions.clickButton('Submit');
     }
 
     async clickAddNewButton(): Promise<void> {

--- a/functional-test/pages/content/action.further.evidence_en.json
+++ b/functional-test/pages/content/action.further.evidence_en.json
@@ -1,9 +1,11 @@
 {
     "eventName": "Action further evidence",
     "sender": "Appellant (or Appointee)",
+    "ftaSender": "FTA",
     "urgentDocType": "Urgent hearing request",
     "reinstatementDocType": "Reinstatement request",
     "testfileone" : "testfile1.pdf",
     "encrytpedFile": "test-encrypted-file.pdf",
-    "corruptedFile": "test-corrupted-file.pdf"
+    "corruptedFile": "test-corrupted-file.pdf",
+    "otherDocType": "Other"
 }

--- a/functional-test/pages/content/action.unprocessed.correspondence.task_en.json
+++ b/functional-test/pages/content/action.unprocessed.correspondence.task_en.json
@@ -1,0 +1,34 @@
+{
+    "name": "Action Unprocessed Correspondence - CTSC",
+    "priority": "high",
+    "assignedToWhenNotAssigned": "Unassigned",
+    "assignedTo": "SSCS ctscadmin",
+    "unassignedManageOptions" : [
+        "Cancel task",
+        "Assign to me"
+    ],
+    "assignedManageOptions" : [
+        "Cancel task",
+        "Mark as done",
+        "Reassign task",
+        "Unassign task"
+    ],
+    "unassignedManageOptionsForCaseAllocator": [
+            "Assign task",
+            "Cancel task",
+            "Assign to me"
+    ],
+    "assignedManageOptionsForCaseAllocator" : [
+        "Cancel task",
+        "Mark as done",
+        "Reassign task",
+        "Unassign task"
+    ],
+    "nextStepsOptions": [
+        "Action Further Evidence"
+    ],
+    "actionFurtherEvidence": {
+        "link": "Action Further Evidence",
+        "eventTitle": "Handle Further Evidence"
+    }
+}

--- a/functional-test/pages/content/supplementary.response_en.json
+++ b/functional-test/pages/content/supplementary.response_en.json
@@ -1,0 +1,11 @@
+{
+    "pageHeading": "Supplementary response",
+    "supplementaryResponseSectionHeading": "Supplementary response",
+    "otherDocumentsSectionHeading": "Other document(s) (Optional)",
+    "testfileone" : "testfile1.pdf",
+    "testfiletwo" : "testfile2.pdf",
+    "testfilethree" : "testfile3.pdf",
+    "ftaState" : "Supplementary response",
+    "poAttendOption" : "No",
+    "cyaHeading" : "Check your answers"
+}

--- a/functional-test/pages/content/upload.document.further.evidence_en.json
+++ b/functional-test/pages/content/upload.document.further.evidence_en.json
@@ -1,0 +1,10 @@
+{
+    "eventName": "Upload document FE",
+    "pageHeading": "Upload further evidence documents",
+    "sectionHeading": "Further evidence documents (Optional)",
+    "documentType": "Appellant evidence",
+    "testfileone" : "testfile1.pdf",
+    "testfiletwo" : "testfile2.pdf",
+    "testfilethree" : "testfile3.pdf",
+    "fileName" : "Test file"
+}

--- a/functional-test/pages/supplementary.response.page.ts
+++ b/functional-test/pages/supplementary.response.page.ts
@@ -1,0 +1,60 @@
+import { Page, expect } from '@playwright/test';
+import { WebAction } from '../common/web.action';
+import supplementaryResponseData  from './content/supplementary.response_en.json';
+
+let webActions: WebAction;
+
+export class SupplementaryResponsePage {
+
+    readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+        webActions = new WebAction(this.page);
+    }
+
+    async verifyPageContent() {
+        await webActions.verifyPageLabel('h1.govuk-heading-l', supplementaryResponseData.pageHeading); //Page heading
+        await webActions.verifyPageLabel('div#dwpSupplementaryResponseDoc_dwpSupplementaryResponseDoc h2.heading-h2', supplementaryResponseData.supplementaryResponseSectionHeading); //Section heading
+        await webActions.verifyPageLabel('div#dwpOtherDoc_dwpOtherDoc h2.heading-h2', supplementaryResponseData.otherDocumentsSectionHeading); //Section heading
+    }
+
+    async uploadSupplementaryResponseDoc(fileName: string): Promise<void> {
+        await webActions.uploadFileUsingAFileChooser('#dwpSupplementaryResponseDoc_documentLink', fileName);
+        await expect(this.page.locator(`div#dwpSupplementaryResponseDoc_dwpSupplementaryResponseDoc span:has-text('Uploading...')`)).toBeVisible();
+        await expect(this.page.locator(`div#dwpSupplementaryResponseDoc_dwpSupplementaryResponseDoc button:has-text('Cancel upload')`)).toBeDisabled();
+        await this.delay(5000);
+    }
+
+    async uploadOtherDoc(fileName: string): Promise<void> {
+        await webActions.uploadFileUsingAFileChooser('#dwpOtherDoc_documentLink', fileName);
+        await expect(this.page.locator(`div#dwpOtherDoc_dwpOtherDoc span:has-text('Uploading...')`)).toBeVisible();
+        await expect(this.page.locator(`div#dwpOtherDoc_dwpOtherDoc button:has-text('Cancel upload')`)).toBeDisabled();
+        await this.delay(5000);
+    }
+
+    async selectFtaState(issueCode: string): Promise<void> {
+        await webActions.chooseOptionByLabel('#dwpState', issueCode);
+    }
+
+    async chooseFtaRecommendPoToAttend(optionVal: string): Promise<void> {
+        await webActions.clickElementById(`#dwpIsOfficerAttending_${optionVal}`);
+    }
+
+    async continueSubmission(): Promise<void> {
+        await webActions.clickButton('Continue');
+    }
+
+    async verifyCYAPageContent(): Promise<void> {
+        await webActions.verifyPageLabel('.govuk-heading-l', supplementaryResponseData.pageHeading); //Heading Text
+        await webActions.verifyPageLabel('form.check-your-answers h2.heading-h2', supplementaryResponseData.cyaHeading);//Check your answers Text.
+    }
+
+    async confirmSubmission(): Promise<void> {
+        await webActions.clickButton('Submit');
+    }
+
+    async delay(ms: number) {
+        return new Promise( resolve => setTimeout(resolve, ms) );
+    }
+}

--- a/functional-test/pages/tabs/tasks.ts
+++ b/functional-test/pages/tabs/tasks.ts
@@ -69,7 +69,7 @@ export class Tasks {
         await expect(this.page.locator(selector)).toBeVisible();
     }
 
-    async cancelTask(taskName: string) {
+    async clickCancelTask(taskName: string) {
         await this.page
             .locator(`//exui-case-task[./*[normalize-space()='${taskName}']]//a[normalize-space()='Cancel task']`).click();
     }
@@ -147,5 +147,13 @@ export class Tasks {
         await expect(this.page.locator('//h2[normalize-space()=\'Active tasks\']')).toBeVisible();
         let task = this.page.locator(`//exui-case-task[./*[normalize-space()='${taskName}']]`);
         await expect(task.getByRole('link', { name: 'Assign task' })).toBeHidden();
+    }
+
+    async cancelTask(taskName: string) {
+        await this.clickCancelTask(taskName);
+        await expect(this.page.locator('h1.govuk-heading-xl')).toHaveText('Cancel a task');
+        await expect(this.page.locator(`exui-task-field:has-text('${taskName}')`)).toBeVisible();
+        await this.page.getByRole('button', { name: 'Cancel task' }).click();
+        await expect(this.page.locator('//h2[normalize-space()=\'Active tasks\']')).toBeVisible();
     }
 }

--- a/functional-test/pages/upload.document.further.evidence.page.ts
+++ b/functional-test/pages/upload.document.further.evidence.page.ts
@@ -1,0 +1,48 @@
+import { Page, expect } from '@playwright/test';
+import { WebAction } from '../common/web.action';
+import uploadDocumentFeData  from './content/upload.document.further.evidence_en.json';
+
+let webActions: WebAction;
+
+export class UploadDocumentFurtherEvidencePage {
+
+    readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+        webActions = new WebAction(this.page);
+    }
+
+    async clickAddNew() {
+        await webActions.clickButton('Add new');;
+    }
+
+    async verifyPageContent() {
+        await webActions.verifyPageLabel('h1.govuk-heading-l', uploadDocumentFeData.pageHeading); //Page heading
+        await webActions.verifyPageLabel('div#draftSscsFurtherEvidenceDocument h2.heading-h2', uploadDocumentFeData.sectionHeading); //Section heading
+    }
+
+    async selectDocumenType(documentType: string) {
+        await expect(this.page.locator('select#draftSscsFurtherEvidenceDocument_0_documentType')).toBeVisible();
+        await webActions.chooseOptionByLabel('select#draftSscsFurtherEvidenceDocument_0_documentType', documentType);
+    }
+
+    async inputFilename(fileName: string){
+        await webActions.inputField('input#draftSscsFurtherEvidenceDocument_0_documentFileName', fileName);
+    }
+
+    async uploadFurtherEvidenceDoc(fileName: string): Promise<void> {
+        await webActions.uploadFileUsingAFileChooser('input#draftSscsFurtherEvidenceDocument_0_documentLink', fileName);
+        await expect(this.page.locator(`div#draftSscsFurtherEvidenceDocument span:has-text('Uploading...')`)).toBeVisible();
+        await expect(this.page.locator(`div#draftSscsFurtherEvidenceDocument button:has-text('Cancel upload')`)).toBeDisabled();
+        await this.delay(5000);
+    }
+
+    async confirmSubmission(): Promise<void> {
+        await webActions.clickButton('Submit');
+    }
+
+    async delay(ms: number) {
+        return new Promise( resolve => setTimeout(resolve, ms) );
+    }
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SSCSSI-263

### Description ###

This PR adds Action Unprocessed correspondence CTSC task work allocation tests. As AAT is not available for work allocation tests at the moment, tests are run locally against demo environment and the tests passed.

![image](https://github.com/hmcts/sscs-ccd-definitions/assets/110388263/8c585e4c-2107-49ed-b3c3-c107f64a23a8)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
